### PR TITLE
Allow dependent on for healthy checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-physical",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Healthcheck middleware for Express 🌡",
   "main": "index.js",
   "repository": "git@github.com:Nevon/express-physical.git",

--- a/src/response/validate.js
+++ b/src/response/validate.js
@@ -16,8 +16,24 @@ const validateDependentOn = (type) => R.contains(type, DEPENDENT_ON_REQUIRED_TYP
   ? R.allPass([R.is(String), R.compose(R.not, R.isEmpty)])
   : R.isNil
 
-module.exports = (
-  name,
+const validateHealthyResponse = (name,
+  type,
+  actionable,
+  severity,
+  dependentOn) => validateName(name) &&
+    validateType(type) &&
+    R.is(Boolean)(actionable) &&
+    R.isNil(severity) &&
+    validateDependentOn(type)(dependentOn)
+
+const validateUnhealthyResponse = (severity,
+  type,
+  dependentOn,
+  message) => validateSeverity(severity) &&
+    validateDependentOn(type)(dependentOn) &&
+    validateMessage(message)
+
+module.exports = (name,
   healthy,
   actionable,
   type,
@@ -31,15 +47,7 @@ module.exports = (
     return false
   }
 
-  if (healthy) {
-    return validateName(name) &&
-           validateType(type) &&
-           R.is(Boolean)(actionable) &&
-           R.isNil(dependentOn) &&
-           R.isNil(severity)
-  }
-
-  return validateSeverity(severity) &&
-         validateDependentOn(type)(dependentOn) &&
-         validateMessage(message)
+  return healthy
+    ? validateHealthyResponse(name, type, actionable, severity, dependentOn)
+    : validateUnhealthyResponse(severity, type, dependentOn, message)
 }


### PR DESCRIPTION
Fixes #3 

The tests that were checking that we were throwing an error when `dependentOn` was present for types it shouldn't be present for were passing by accident because we threw an error because the field was present in a healthy response.

Now we validate `dependentOn` for the types that we should, for both healthy and unhealthy responses.