### PR TITLE
Validate against schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ node_js:
   - node
   - lts/*
 cache: yarn
+env:
+  - STAGE=static-analysis
+  - STAGE=unit
+  - STAGE=integration
+script: "npm run test:$STAGE"
 deploy:
   provider: npm
   email: tommy.brunn@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- node
-- lts/*
+  - node
+  - lts/*
+cache: yarn
 deploy:
   provider: npm
   email: tommy.brunn@gmail.com

--- a/__api_tests__/lib/jest-ajv/index.js
+++ b/__api_tests__/lib/jest-ajv/index.js
@@ -1,0 +1,5 @@
+const matcherUsing = require('./matcher')
+
+module.exports = (ajv) => expect.extend({
+  toMatchSchema: matcherUsing(ajv)
+})

--- a/__api_tests__/lib/jest-ajv/matcher.js
+++ b/__api_tests__/lib/jest-ajv/matcher.js
@@ -1,0 +1,15 @@
+module.exports = (ajv) => (response, schema) => {
+  const pass = ajv.validate(schema, response)
+
+  if (pass) {
+    return {
+      pass,
+      message: () => `All properties should not match`
+    }
+  } else {
+    return {
+      pass,
+      message: () => `\n${ajv.errorsText(ajv.errors, { separator: '\n' })}\n`
+    }
+  }
+}

--- a/__api_tests__/resources/schema.json
+++ b/__api_tests__/resources/schema.json
@@ -1,0 +1,135 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Healthchecks"
+  },
+  "paths": {
+    "/healthcheck": {
+      "get": {
+        "summary": "Health Check endpoint",
+        "description": "Each Kasper service must have an endpoint where the health of the service instance can be monitored",
+        "operationId": "getServiceInstanceHealth",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Health Check",
+            "schema": {
+              "$ref": "#/definitions/ServiceInstanceHealthDto"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DependentOnDto": {
+      "type": "object",
+      "required": [
+        "service_name"
+      ],
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "The name of the service or infrastructure component that this check depends on."
+        }
+      }
+    },
+    "HealthCheckResponseDto": {
+      "type": "object",
+      "required": [
+        "actionable",
+        "healthy",
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the check."
+        },
+        "healthy": {
+          "type": "boolean",
+          "description": "healthy: true|false."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of this check.",
+          "enum": [
+            "SELF",
+            "METRICS",
+            "INFRASTRUCTURE",
+            "INTERNAL_DEPENDENCY",
+            "EXTERNAL_DEPENDENCY",
+            "INTERNET_CONNECTIVITY"
+          ]
+        },
+        "dependent_on": {
+          "description": "Describes which service this check depends on. Mandatory for types 'INFRASTRUCTURE', 'INTERNAL_DEPENDENCY' and 'EXTERNAL_DEPENDENCY', excluded otherwise.",
+          "$ref": "#/definitions/DependentOnDto"
+        },
+        "severity": {
+          "type": "string",
+          "description": "Mandatory if the check is not healthy, excluded otherwise.",
+          "enum": [
+            "WARNING",
+            "CRITICAL",
+            "DOWN'"
+          ]
+        },
+        "actionable": {
+          "type": "boolean",
+          "description": "Describes whether or not this team can take any action when the check is unhealthy"
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the status of the check. Mandatory if unhealthy."
+        },
+        "link": {
+          "type": "string",
+          "description": "A link to where more information can be gotten."
+        },
+        "additional_info": {
+          "type": "object",
+          "description": " Additional information about this check. Monks Does not care about it, it's just pass through for end users!",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "description": "List of tags for the service that can be used group multiple services together.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServiceInstanceHealthDto": {
+      "type": "object",
+      "required": [
+        "healthy",
+        "unhealthy"
+      ],
+      "properties": {
+        "unhealthy": {
+          "type": "array",
+          "description": "List of unhealthy checks.",
+          "items": {
+            "$ref": "#/definitions/HealthCheckResponseDto"
+          }
+        },
+        "healthy": {
+          "type": "array",
+          "description": "List of healthy checks.",
+          "items": {
+            "$ref": "#/definitions/HealthCheckResponseDto"
+          }
+        }
+      }
+    }
+  }
+}

--- a/__api_tests__/schema-validation.spec.js
+++ b/__api_tests__/schema-validation.spec.js
@@ -1,0 +1,92 @@
+const Ajv = require('ajv')
+const request = require('supertest')
+const express = require('express')
+const physical = require('../index')
+
+const schema = require('./resources/schema')
+
+const ajv = new Ajv()
+ajv.addSchema(schema, 'schema.json')
+require('./lib/jest-ajv')(ajv)
+
+const path = '/healthcheck'
+
+const passingCheck = () => physical.response({
+  name: 'Sample passing check',
+  actionable: false,
+  healthy: true,
+  type: physical.type.SELF
+})
+
+const failingCheck = () => physical.response({
+  name: 'Sample passing check',
+  actionable: false,
+  healthy: false,
+  severity: physical.severity.WARNING,
+  message: 'Something failed',
+  type: physical.type.SELF
+})
+
+describe('When the healthchecks are passing', () => {
+  const app = express()
+
+  app.use(path, physical([passingCheck]))
+
+  test('The schema should be valid', () => {
+    return request(app)
+      .get(path)
+      .expect(200)
+      .expect('Content-Type', /application\/json/)
+      .then(response => {
+        expect(response.body).toMatchSchema({ $ref: 'schema.json#/definitions/ServiceInstanceHealthDto' })
+      })
+  })
+})
+
+describe('When the healthchecks are all failing', () => {
+  const app = express()
+
+  app.use(path, physical([failingCheck]))
+
+  test('The schema should be valid', () => {
+    return request(app)
+      .get(path)
+      .expect(500)
+      .expect('Content-Type', /application\/json/)
+      .then(response => {
+        expect(response.body).toMatchSchema({ $ref: 'schema.json#/definitions/ServiceInstanceHealthDto' })
+      })
+  })
+})
+
+describe('When some of the checks are failing', () => {
+  const app = express()
+
+  app.use(path, physical([passingCheck, failingCheck]))
+
+  test('The schema should be valid', () => {
+    return request(app)
+      .get(path)
+      .expect(500)
+      .expect('Content-Type', /application\/json/)
+      .then(response => {
+        expect(response.body).toMatchSchema({ $ref: 'schema.json#/definitions/ServiceInstanceHealthDto' })
+      })
+  })
+})
+
+describe('When there are no healthchecks', () => {
+  const app = express()
+
+  app.use(path, physical([]))
+
+  test('The schema should be valid', () => {
+    return request(app)
+      .get(path)
+      .expect(200)
+      .expect('Content-Type', /application\/json/)
+      .then(response => {
+        expect(response.body).toMatchSchema({ $ref: 'schema.json#/definitions/ServiceInstanceHealthDto' })
+      })
+  })
+})

--- a/__tests__/middleware.spec.js
+++ b/__tests__/middleware.spec.js
@@ -26,7 +26,7 @@ describe('When the checks complete', () => {
     test('It sends the serialized responses with 200 status code', () => {
       const statusMock = jest.fn()
       const res = {
-        send: jest.fn(),
+        json: jest.fn(),
         status: statusMock
       }
       statusMock.mockReturnValue(res)
@@ -42,13 +42,14 @@ describe('When the checks complete', () => {
 
       physical([check])({}, res, () => {})
 
-      expect(res.send).toHaveBeenCalledWith({
+      expect(res.json).toHaveBeenCalledWith({
         healthy: [{
           name: 'Test',
           healthy: true,
           type: 'SELF',
           actionable: false
-        }]
+        }],
+        unhealthy: []
       })
       expect(res.status).toHaveBeenCalledWith(200)
     })
@@ -58,7 +59,7 @@ describe('When the checks complete', () => {
     test('It sends the serialized responses with 500 status code', () => {
       const statusMock = jest.fn()
       const res = {
-        send: jest.fn(),
+        json: jest.fn(),
         status: statusMock
       }
       statusMock.mockReturnValue(res)
@@ -69,20 +70,21 @@ describe('When the checks complete', () => {
           healthy: false,
           type: physical.type.SELF,
           actionable: false,
-          severity: physical.severity.WARN,
+          severity: physical.severity.WARNING,
           message: 'Something is failing'
         })
       }
 
       physical([check])({}, res, () => {})
 
-      expect(res.send).toHaveBeenCalledWith({
+      expect(res.json).toHaveBeenCalledWith({
+        healthy: [],
         unhealthy: [{
           name: 'Failing Test',
           healthy: false,
           type: 'SELF',
           actionable: false,
-          severity: 'WARN',
+          severity: 'WARNING',
           message: 'Something is failing'
         }]
       })

--- a/__tests__/response.spec.js
+++ b/__tests__/response.spec.js
@@ -42,7 +42,7 @@ describe('Response', () => {
 
     describe('When the check is healthy', () => {
       test('It should throw an error if severity is provided', () => {
-        expect(() => response(Object.assign({}, healthyResponse, { severity: severities.WARN }))).toThrow()
+        expect(() => response(Object.assign({}, healthyResponse, { severity: severities.WARNING }))).toThrow()
       })
     })
 

--- a/package.json
+++ b/package.json
@@ -7,15 +7,21 @@
   "author": "Tommy Brunn <tommy.brunn@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "npm run lint && npm run test:unit",
-    "test:unit": "NODE_ENV=test jest",
+    "test": "npm run test:static-analysis && npm run test:unit && npm run test:integration",
+    "test:static-analysis": "npm run lint",
+    "test:unit": "NODE_ENV=test jest /__tests__/",
     "test:unit:watch": "npm run test:unit -- --watch",
+    "test:integration": "NODE_ENV=test jest /__api_tests__/",
+    "test:integration:watch": "npm run test:integration -- --watch",
     "lint": "standard",
     "debug": "node debug --harmony ./node_modules/jest-cli/bin/jest.js --runInBand -i"
   },
   "devDependencies": {
+    "ajv": "^5.0.0",
+    "express": "^4.15.2",
     "jest": "^17.0.3",
-    "standard": "^8.6.0"
+    "standard": "^8.6.0",
+    "supertest": "^3.0.0"
   },
   "standard": {
     "globals": [

--- a/src/constants/severities.js
+++ b/src/constants/severities.js
@@ -1,5 +1,5 @@
 module.exports = {
-  WARN: 'WARN',
+  WARNING: 'WARNING',
   CRITICAL: 'CRITICAL',
   DOWN: 'DOWN'
 }

--- a/src/constants/severities.js
+++ b/src/constants/severities.js
@@ -1,5 +1,6 @@
 module.exports = {
   WARNING: 'WARNING',
+  WARN: 'WARNING', // Backwards compatibility
   CRITICAL: 'CRITICAL',
   DOWN: 'DOWN'
 }

--- a/src/marshal.js
+++ b/src/marshal.js
@@ -4,5 +4,9 @@ const serialize = require('./response/serialize')
 
 const byHealth = R.groupBy((response) => response.healthy ? 'healthy' : 'unhealthy')
 const serializeAll = R.curry(R.map)(serialize)
+const addRequiredEmptyGroups = response => Object.assign({
+  healthy: [],
+  unhealthy: []
+}, response)
 
-module.exports = R.compose(byHealth, serializeAll)
+module.exports = R.compose(addRequiredEmptyGroups, byHealth, serializeAll)

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -8,6 +8,8 @@ module.exports = (checks = []) => {
   return (req, res, next) => runChecks(
     (err, result) => err
       ? next(err)
-      : res.status(hasFailingChecks(result) ? 500 : 200).send(marshal(result))
+      : res
+          .status(hasFailingChecks(result) ? 500 : 200)
+          .json(marshal(result))
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,13 @@ abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
+accepts@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
+  dependencies:
+    mime-types "~2.1.11"
+    negotiator "0.6.1"
+
 acorn-globals@^1.0.4:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-1.0.9.tgz#55bb5e98691507b74579d0513413217c380c54cf"
@@ -41,6 +48,13 @@ ajv-keywords@^1.0.0:
 ajv@^4.7.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.9.1.tgz#08e1b0a5fddc8b844d28ca7b03510e78812ee3a0"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
+ajv@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.0.0.tgz#a2c717764e8036d15fd227b070ddaf7867ab413a"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -100,6 +114,10 @@ array-differ@^1.0.0:
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -469,6 +487,10 @@ commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+component-emitter@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -481,13 +503,33 @@ concat-stream@^1.4.6:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+
 content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
+content-type@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
+
 convert-source-map@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.3.0.tgz#e9f3e9c6e2728efc2676696a70eb382f73106a67"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+cookiejar@^2.0.6:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -528,6 +570,18 @@ dashdash@^1.12.0:
 debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+
+debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  dependencies:
+    ms "0.7.2"
+
+debug@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
+  dependencies:
+    ms "0.7.2"
 
 debug@^2.1.1, debug@^2.2.0:
   version "2.3.3"
@@ -570,6 +624,14 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
+depd@1.1.0, depd@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -592,6 +654,14 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+encodeurl@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
 "errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
@@ -656,6 +726,10 @@ es6-weak-map@^2.0.1:
     es5-ext "^0.10.8"
     es6-iterator "2"
     es6-symbol "3"
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -781,6 +855,10 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+etag@~1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
+
 event-emitter@~0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.4.tgz#8d63ddfb4cfe1fae3b32ca265c4c720222080bb5"
@@ -810,7 +888,40 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@~3.0.0:
+express@^4.15.2:
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.15.2.tgz#af107fc148504457f2dca9a6f2571d7129b97b35"
+  dependencies:
+    accepts "~1.3.3"
+    array-flatten "1.1.1"
+    content-disposition "0.5.2"
+    content-type "~1.0.2"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.1"
+    depd "~1.1.0"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.0"
+    finalhandler "~1.0.0"
+    fresh "0.5.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    path-to-regexp "0.1.7"
+    proxy-addr "~1.1.3"
+    qs "6.4.0"
+    range-parser "~1.2.0"
+    send "0.15.1"
+    serve-static "1.12.1"
+    setprototypeof "1.0.3"
+    statuses "~1.3.1"
+    type-is "~1.6.14"
+    utils-merge "1.0.0"
+    vary "~1.1.0"
+
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -869,6 +980,18 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+finalhandler@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.1.tgz#bcd15d1689c0e5ed729b6f7f541a6df984117db8"
+  dependencies:
+    debug "2.6.3"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    statuses "~1.3.1"
+    unpipe "~1.0.0"
+
 find-root@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
@@ -903,13 +1026,25 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.1.1:
+form-data@^2.1.1, form-data@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formidable@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
+
+forwarded@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
+
+fresh@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1059,6 +1194,15 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+http-errors@~1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.1.tgz#5f8b8ed98aca545656bf572997387f904a722257"
+  dependencies:
+    depd "1.1.0"
+    inherits "2.0.3"
+    setprototypeof "1.0.3"
+    statuses ">= 1.3.1 < 2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -1090,7 +1234,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.1:
+inherits@2, inherits@2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1125,6 +1269,10 @@ invariant@^2.2.0:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+ipaddr.js@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -1757,9 +1905,21 @@ marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+
+methods@^1.1.1, methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
 micromatch@^2.3.11:
   version "2.3.11"
@@ -1783,11 +1943,25 @@ mime-db@~1.25.0:
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
+mime-db@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
+
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.7:
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
   dependencies:
     mime-db "~1.25.0"
+
+mime-types@~2.1.15:
+  version "2.1.15"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
+  dependencies:
+    mime-db "~1.27.0"
+
+mime@1.3.4, mime@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
   version "3.0.3"
@@ -1835,6 +2009,10 @@ mute-stream@0.0.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
 node-emoji@^1.4.1:
   version "1.4.3"
@@ -1900,6 +2078,12 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  dependencies:
+    ee-first "1.1.1"
+
 once@1.x, once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -1961,6 +2145,10 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+parseurl@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -1978,6 +2166,10 @@ path-is-inside@^1.0.1:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -2037,6 +2229,13 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+proxy-addr@~1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
+  dependencies:
+    forwarded "~0.1.0"
+    ipaddr.js "1.3.0"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -2044,6 +2243,10 @@ prr@~0.0.0:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+qs@6.4.0, qs@^6.1.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 qs@~6.3.0:
   version "6.3.0"
@@ -2060,6 +2263,10 @@ randomatic@^1.1.3:
     is-number "^2.0.2"
     kind-of "^3.0.2"
 
+range-parser@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -2075,7 +2282,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@~2.0.0:
+readable-stream@^2.0.5, readable-stream@~2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
@@ -2231,9 +2438,40 @@ sax@^1.1.4:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+send@0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.15.1.tgz#8a02354c26e6f5cca700065f5f0cdeba90ec7b5f"
+  dependencies:
+    debug "2.6.1"
+    depd "~1.1.0"
+    destroy "~1.0.4"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.0"
+    fresh "0.5.0"
+    http-errors "~1.6.1"
+    mime "1.3.4"
+    ms "0.7.2"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.3.1"
+
+serve-static@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.1.tgz#7443a965e3ced647aceb5639fa06bf4d1bbe0039"
+  dependencies:
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    parseurl "~1.3.1"
+    send "0.15.1"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 shelljs@^0.7.5:
   version "0.7.5"
@@ -2346,6 +2584,10 @@ standard@^8.6.0:
     eslint-plugin-standard "~2.0.1"
     standard-engine "~5.2.0"
 
+"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -2392,6 +2634,28 @@ strip-bom@^3.0.0:
 strip-json-comments@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+
+superagent@^3.0.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.5.2.tgz#3361a3971567504c351063abeaae0faa23dbf3f8"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.0.6"
+    debug "^2.2.0"
+    extend "^3.0.0"
+    form-data "^2.1.1"
+    formidable "^1.1.1"
+    methods "^1.1.1"
+    mime "^1.3.4"
+    qs "^6.1.0"
+    readable-stream "^2.0.5"
+
+supertest@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.0.0.tgz#8d4bb68fd1830ee07033b1c5a5a9a4021c965296"
+  dependencies:
+    methods "~1.1.2"
+    superagent "^3.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -2492,6 +2756,13 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-is@~1.6.14:
+  version "1.6.15"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.15"
+
 typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -2513,6 +2784,10 @@ uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
+unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -2522,6 +2797,10 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+utils-merge@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
 uuid@^3.0.0:
   version "3.0.1"
@@ -2533,6 +2812,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+vary@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
This introduces a schema validation stage to the pipeline, which validates the responses against a defined schema.

As part of this, I found some irregularities which will change the API somewhat:

* Both `healthy` and `unhealthy` will be present on the top level object even if they are empty lists.
* `physical.severity.WARN` has been replaced by `physical.severity.WARNING`. In order to be backwards compatible, you can still use `physical.severity.WARN`, but the resulting API output will be `WARNING`. This will be removed eventually, so I don't recommend depending on it.