### PR TITLE
Custom error for invalid healthchecks

### DIFF
--- a/__tests__/invalid-healthcheck-response.spec.js
+++ b/__tests__/invalid-healthcheck-response.spec.js
@@ -1,0 +1,10 @@
+const InvalidHealthCheckResponse = require("../src/response/invalid-healthcheck-response");
+
+describe("InvalidHealthCheckResponse", () => {
+  it("should contain the responseData as a custom field", () => {
+    const responseData = { foo: "bar" };
+    expect(
+      new InvalidHealthCheckResponse("message", responseData).responseData
+    ).toEqual(responseData);
+  });
+});

--- a/__tests__/response.spec.js
+++ b/__tests__/response.spec.js
@@ -2,6 +2,7 @@ const R = require("ramda");
 
 const response = require("../src/response/response");
 const serialize = require("../src/response/serialize");
+const InvalidHealthcheckResponse = require("../src/response/invalid-healthcheck-response");
 const { types, severities } = require("../src/constants");
 
 const baseResponse = {
@@ -38,7 +39,7 @@ describe("Response", () => {
           response(
             Object.assign({}, healthyResponse, { severity: severities.WARNING })
           )
-        ).toThrow();
+        ).toThrow(InvalidHealthcheckResponse);
       });
     });
 
@@ -47,7 +48,9 @@ describe("Response", () => {
 
       requiredFieldsWhenUnhealthy.forEach(field => {
         test(`It should throw an error when ${field} is missing`, () => {
-          expect(() => response(R.omit([field], unhealthyResponse))).toThrow();
+          expect(() => response(R.omit([field], unhealthyResponse))).toThrow(
+            InvalidHealthcheckResponse
+          );
         });
       });
     });
@@ -62,7 +65,7 @@ describe("Response", () => {
         test(type, () => {
           expect(() =>
             response(Object.assign({}, unhealthyResponse, { type }))
-          ).toThrow();
+          ).toThrow(InvalidHealthcheckResponse);
         });
       });
     });
@@ -74,7 +77,7 @@ describe("Response", () => {
             response(
               Object.assign({}, healthyResponse, { dependentOn: "foobar" })
             )
-          ).toThrow();
+          ).toThrow(InvalidHealthcheckResponse);
         });
       });
     });

--- a/src/response/invalid-healthcheck-response.js
+++ b/src/response/invalid-healthcheck-response.js
@@ -1,0 +1,7 @@
+module.exports = class InvalidHealthcheckResponse extends Error {
+  constructor(message, responseData, ...args) {
+    super([message, ...args]);
+    this.responseData = responseData;
+    Error.captureStackTrace(this, InvalidHealthcheckResponse);
+  }
+};

--- a/src/response/response.js
+++ b/src/response/response.js
@@ -1,5 +1,6 @@
 const R = require("ramda");
 
+const InvalidHealthcheckResponse = require("./invalid-healthcheck-response");
 const validate = require("./validate");
 
 const createResponse = responseData =>
@@ -44,7 +45,10 @@ module.exports = function(responseData) {
       link
     )
   ) {
-    throw new Error("Invalid input for HealthCheckResponse", responseData);
+    throw new InvalidHealthcheckResponse(
+      "Invalid input for HealthCheckResponse",
+      responseData
+    );
   }
 
   return createResponse(responseData);


### PR DESCRIPTION
Turns out `Error` only takes a single argument 😅