### PR TITLE
Refactor response validation.

### DIFF
--- a/__tests__/response.spec.js
+++ b/__tests__/response.spec.js
@@ -75,7 +75,10 @@ describe("Response", () => {
         test(type, () => {
           expect(() =>
             response(
-              Object.assign({}, healthyResponse, { dependentOn: "foobar" })
+              Object.assign({}, healthyResponse, {
+                type,
+                dependentOn: "foobar"
+              })
             )
           ).toThrow(InvalidHealthcheckResponse);
         });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "async": "^2.6.0",
     "ramda": "^0.25.0",
-    "snakecase-keys": "^1.1.0"
+    "snakecase-keys": "^1.1.0",
+    "spected": "^0.6.0"
   },
   "jest": {
     "verbose": true,

--- a/src/response/response.js
+++ b/src/response/response.js
@@ -3,38 +3,34 @@ const R = require("ramda");
 const InvalidHealthcheckResponse = require("./invalid-healthcheck-response");
 const validate = require("./validate");
 
+const RESPONSE_FORMAT = {
+  name: undefined,
+  healthy: undefined,
+  actionable: undefined,
+  type: undefined,
+  severity: undefined,
+  message: undefined,
+  dependentOn: undefined,
+  info: undefined,
+  link: undefined
+};
+
 const createResponse = responseData =>
-  R.pick(
-    [
-      "name",
-      "healthy",
-      "actionable",
-      "type",
-      "severity",
-      "message",
-      "dependentOn",
-      "info",
-      "link"
-    ],
-    responseData
-  );
+  R.pick(Object.keys(RESPONSE_FORMAT), responseData);
+
+const someFail = results =>
+  R.not(R.all(R.equals(true), Object.values(results)));
+
+const isMessage = R.compose(R.not, R.is(Boolean));
+const firstMessage = R.compose(R.head, R.filter(isMessage), R.values);
 
 module.exports = function(responseData) {
-  if (
-    !validate(
-      responseData.name,
-      responseData.healthy,
-      responseData.actionable,
-      responseData.type,
-      responseData.severity,
-      responseData.message,
-      responseData.dependentOn,
-      responseData.info,
-      responseData.link
-    )
-  ) {
+  const validatable = Object.assign({}, RESPONSE_FORMAT, responseData);
+  const validationResult = validate(validatable);
+
+  if (someFail(validationResult)) {
     throw new InvalidHealthcheckResponse(
-      "Invalid input for HealthCheckResponse",
+      firstMessage(validationResult),
       responseData
     );
   }

--- a/src/response/validate.js
+++ b/src/response/validate.js
@@ -1,4 +1,5 @@
 const R = require("ramda");
+const { validate } = require("spected");
 
 const types = require("../constants/types");
 const severities = require("../constants/severities");
@@ -10,51 +11,82 @@ const DEPENDENT_ON_REQUIRED_TYPES = [
 ];
 
 const notEmpty = R.compose(R.not, R.isEmpty);
-const validateName = R.allPass([R.is(String), notEmpty]);
-const validateMessage = R.allPass([R.is(String), notEmpty]);
-const validateHealthy = R.is(Boolean);
-const validateType = R.curry(R.contains)(R.__, R.keys(types));
-const validateSeverity = R.curry(R.contains)(R.__, R.keys(severities));
+const notNil = R.compose(R.not, R.isNil);
+const isString = R.is(String);
+const isBoolean = R.is(Boolean);
+const oneOf = collection => R.curry(R.contains)(R.__, R.keys(collection));
 
-const validateDependentOn = type =>
-  R.contains(type, DEPENDENT_ON_REQUIRED_TYPES)
-    ? R.allPass([R.is(String), R.compose(R.not, R.isEmpty)])
-    : R.isNil;
+const createSuffix = healthy =>
+  `when healthcheck is ${healthy ? "healthy" : "unhealthy"}`;
+const SUFFIX_HEALTHY_MSG = createSuffix(true);
+const SUFFIX_UNHEALTHY_MSG = createSuffix(false);
 
-const validateHealthyResponse = (
-  name,
-  type,
-  actionable,
-  severity,
-  dependentOn
-) =>
-  validateName(name) &&
-  validateType(type) &&
-  R.is(Boolean)(actionable) &&
-  R.isNil(severity) &&
-  validateDependentOn(type)(dependentOn);
+const healthyCheckMessage = msg => `${msg} ${SUFFIX_HEALTHY_MSG}`;
+const unhealthyCheckMessage = msg => `${msg} ${SUFFIX_UNHEALTHY_MSG}`;
 
-const validateUnhealthyResponse = (severity, type, dependentOn, message) =>
-  validateSeverity(severity) &&
-  validateDependentOn(type)(dependentOn) &&
-  validateMessage(message);
+const commonRules = input => ({
+  healthy: [[isBoolean, "Healthy should be a boolean"]],
+  dependentOn: R.contains(input.type, DEPENDENT_ON_REQUIRED_TYPES)
+    ? [
+        [isString, "DependentOn should be a string"],
+        [
+          notEmpty,
+          `DependentOn is required when type is one of ${DEPENDENT_ON_REQUIRED_TYPES.join(
+            ", "
+          )}`
+        ]
+      ]
+    : [
+        [
+          R.isNil,
+          `DependentOn should be omitted when type is one of ${R.values(
+            R.omit(DEPENDENT_ON_REQUIRED_TYPES, types)
+          ).join(", ")}`
+        ]
+      ]
+});
 
-module.exports = (
-  name,
-  healthy,
-  actionable,
-  type,
-  severity,
-  message,
-  dependentOn,
-  info,
-  link
-) => {
-  if (!validateHealthy(healthy)) {
-    return false;
-  }
+const healthyRules = input => ({
+  name: [
+    [isString, healthyCheckMessage("Name should be a string")],
+    [notEmpty, healthyCheckMessage("Name should not be empty")]
+  ],
+  type: [
+    [
+      oneOf(types),
+      healthyCheckMessage(`Type should be one of ${R.keys(types).join(", ")}`)
+    ]
+  ],
+  actionable: [
+    [isBoolean, healthyCheckMessage("Actionable should be a boolean")]
+  ],
+  severity: [[R.isNil, healthyCheckMessage("Severity should be omitted")]]
+});
 
-  return healthy
-    ? validateHealthyResponse(name, type, actionable, severity, dependentOn)
-    : validateUnhealthyResponse(severity, type, dependentOn, message);
-};
+const unhealthyRules = input => ({
+  severity: [
+    [notNil, unhealthyCheckMessage("Severity is required")],
+    [
+      oneOf(severities),
+      unhealthyCheckMessage(
+        `Severity should be one of ${R.keys(severities).join(", ")}`
+      )
+    ]
+  ],
+  message: [
+    [isString, unhealthyCheckMessage("Message should be a string")],
+    [notEmpty, unhealthyCheckMessage("Message is required")]
+  ]
+});
+
+const rules = input =>
+  Object.assign(
+    commonRules(input),
+    R.ifElse(({ healthy }) => healthy === true, healthyRules, unhealthyRules)(
+      input
+    )
+  );
+
+const validator = R.curry(validate(() => true, R.head));
+
+module.exports = input => validator(rules(input))(input);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,6 +2469,10 @@ qs@^6.1.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+ramda@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
+
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
@@ -2824,6 +2828,12 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+spected@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/spected/-/spected-0.6.0.tgz#c725dab32d6020ef7f2fb081e178c08b0618740f"
+  dependencies:
+    ramda "^0.24.1"
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Fixes #7 by introducing more granular error messaging for response objects. Signature is unchanged, but the InvalidHealthcheckResponse error message will contain more information about what exactly is wrong with the response.

<img width="901" alt="screen shot 2017-11-11 at 15 31 02" src="https://user-images.githubusercontent.com/83586/32690331-5ed4a270-c6f5-11e7-9923-b5c1d910e01e.png">
