### PR TITLE
Copy `info` field to `additional_info`

### DIFF
--- a/__tests__/response.spec.js
+++ b/__tests__/response.spec.js
@@ -30,7 +30,32 @@ describe("Response", () => {
 
     requiredFields.forEach(field => {
       test(`It should throw an error when ${field} is missing`, () => {
-        expect(() => response(R.omit([field], healthyResponse)));
+        expect(() => response(R.omit([field], healthyResponse))).toThrow(
+          InvalidHealthcheckResponse
+        );
+      });
+    });
+
+    const infoFields = ["info", "additional_info"];
+    infoFields.forEach(field => {
+      test(`It should throw an error when ${field} is not an object`, () => {
+        expect(() =>
+          response(
+            Object.assign({}, healthyResponse, { info: "not an object" })
+          )
+        ).toThrow(InvalidHealthcheckResponse);
+      });
+
+      test(`It should not throw an error when ${field} is omitted`, () => {
+        expect(() => response(R.omit([field], healthyResponse))).not.toThrow();
+      });
+
+      test(`It should not throw an error when ${field} is an object`, () => {
+        expect(() =>
+          response(
+            Object.assign({}, healthyResponse, { info: { foo: { bar: true } } })
+          )
+        ).not.toThrow();
       });
     });
 
@@ -101,6 +126,12 @@ describe("Response", () => {
       expected["service_name"] = "foo";
 
       expect(actual["dependent_on"]).toEqual(expected);
+    });
+
+    test("should copy info to additionalInfo", () => {
+      const actual = serializeResponse(healthyResponse);
+
+      expect(actual["additional_info"]).toEqual(actual.info);
     });
 
     test("should remove empty fields", () => {

--- a/src/response/serialize.js
+++ b/src/response/serialize.js
@@ -17,4 +17,15 @@ const formatDependentOn = R.when(
   obj => Object.assign(obj, { dependentOn: { serviceName: obj.dependentOn } })
 );
 
-module.exports = R.compose(snakeCaseKeys, formatDependentOn, removeEmptyFields);
+// `info` is also available as `additional_info` for compatibility reasons
+const copyInfoField = R.when(
+  R.compose(R.curry(R.is(Object)), R.curry(R.prop("info"))),
+  obj => Object.assign(obj, { additionalInfo: obj.info })
+);
+
+module.exports = R.compose(
+  snakeCaseKeys,
+  formatDependentOn,
+  copyInfoField,
+  removeEmptyFields
+);

--- a/src/response/validate.js
+++ b/src/response/validate.js
@@ -15,6 +15,7 @@ const notEmpty = R.compose(R.not, R.isEmpty);
 const notNil = R.compose(R.not, R.isNil);
 const isString = R.is(String);
 const isBoolean = R.is(Boolean);
+const isObject = R.is(Object);
 const oneOf = collection => R.curry(R.contains)(R.__, R.keys(collection));
 
 const createSuffix = healthy =>
@@ -27,6 +28,7 @@ const unhealthyCheckMessage = msg => `${msg} ${SUFFIX_UNHEALTHY_MSG}`;
 
 const commonRules = input => ({
   healthy: [[isBoolean, "Healthy should be a boolean"]],
+  info: [[R.either(R.isNil, isObject), "Info should be an object"]],
   dependentOn: R.contains(input.type, DEPENDENT_ON_REQUIRED_TYPES)
     ? [
         [isString, "DependentOn should be a string"],


### PR DESCRIPTION
The schema actually specifies that the response can contain `additional_info`, not `info`. `info` is kept for backwards compatibility, but copied over to `additional_info` during serialization.